### PR TITLE
Mount to local path by default

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,10 +7,10 @@ services:
 
     volumes:
       # Update paths to mount models and output paths to your custom paths like this, e.g:
-      # - C:/your-local-path/AdvancedLivePortrait-WebUI/models:/AdvancedLivePortrait-WebUI/models
-      # - C:/your-local-path/AdvancedLivePortrait-WebUI/outputs:/AdvancedLivePortrait-WebUI/outputs
-      - /AdvancedLivePortrait-WebUI/models
-      - /AdvancedLivePortrait-WebUI/outputs
+      # - /local/paths/models:/AdvancedLivePortrait-WebUI/models
+      # - /local/paths/outputs:/AdvancedLivePortrait-WebUI/outputs
+      - ../models:/AdvancedLivePortrait-WebUI/models
+      - ../outputs:/AdvancedLivePortrait-WebUI/outputs
 
     ports:
       - "7860:7860"


### PR DESCRIPTION
## Related issues / PRs
Add mount paths by default

## Summarize Changes
1. Most of users would run 
```
docker compose -f docker/docker-compose.yaml up
```
in the root project directory, so add mount paths by default
